### PR TITLE
Publish to Open VSX for Cursor compatibility

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -22,10 +22,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build extension bundle
         run: npm run package

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,31 +1,39 @@
-name: "Publish VS Code extension"
+name: Publish Extension
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Clone repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
-      - name: Login to VSCE
-        run: echo "${{ secrets.MARKETPLACE_TOKEN }}" | npx vsce login jirkavrba
+      - name: Build extension bundle
+        run: npm run package
 
-      - name: Build package
-        run: npx vsce package
+      - name: Package VSIX
+        run: npx --yes @vscode/vsce package
 
-      - name: Publish package
-        run: npx vsce publish
-on:
-  push:
-    branches: 
-      - main
+      - name: Publish to VS Code Marketplace
+        if: ${{ secrets.VSCE_TOKEN != '' }}
+        run: npx --yes @vscode/vsce publish -p "${{ secrets.VSCE_TOKEN }}"
+
+      - name: Publish to Open VSX
+        if: ${{ secrets.OPEN_VSX_TOKEN != '' }}
+        run: npx --yes ovsx publish *.vsix -p "${{ secrets.OPEN_VSX_TOKEN }}"

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,6 +1,6 @@
 name: Publish Extension
 
-on:
+"on":
   workflow_dispatch:
   push:
     tags:
@@ -31,9 +31,9 @@ jobs:
         run: npx --yes @vscode/vsce package
 
       - name: Publish to VS Code Marketplace
-        if: ${{ secrets.VSCE_TOKEN != '' }}
+        if: ${{ secrets.VSCE_TOKEN }}
         run: npx --yes @vscode/vsce publish -p "${{ secrets.VSCE_TOKEN }}"
 
       - name: Publish to Open VSX
-        if: ${{ secrets.OPEN_VSX_TOKEN != '' }}
+        if: ${{ secrets.OPEN_VSX_TOKEN }}
         run: npx --yes ovsx publish *.vsix -p "${{ secrets.OPEN_VSX_TOKEN }}"

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+      OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,9 +34,9 @@ jobs:
         run: npx --yes @vscode/vsce package
 
       - name: Publish to VS Code Marketplace
-        if: ${{ secrets.VSCE_TOKEN }}
-        run: npx --yes @vscode/vsce publish -p "${{ secrets.VSCE_TOKEN }}"
+        if: ${{ env.VSCE_TOKEN != '' }}
+        run: npx --yes @vscode/vsce publish -p "$VSCE_TOKEN"
 
       - name: Publish to Open VSX
-        if: ${{ secrets.OPEN_VSX_TOKEN }}
-        run: npx --yes ovsx publish *.vsix -p "${{ secrets.OPEN_VSX_TOKEN }}"
+        if: ${{ env.OPEN_VSX_TOKEN != '' }}
+        run: npx --yes ovsx publish *.vsix -p "$OPEN_VSX_TOKEN"

--- a/README.md
+++ b/README.md
@@ -18,3 +18,27 @@ Enjoy skibidi rizz ohio brainrot stimulation right in your vscode editor! Feel t
 - [@Abb1x](https://github.com/Abb1x) for adding Minecraft parkour videos!
 - [@styxpilled](https://github.com/styxpilled) for adding Better Call Saul best moments
 - [@paolomartinez](https://github.com/paolomartinez) for adding Family Guy best moments
+
+## Cursor availability
+
+Cursor does not always index all VS Code Marketplace extensions directly. To maximize compatibility, this project publishes to both marketplaces:
+
+- VS Code Marketplace
+- Open VSX (used by Cursor-compatible extension flows)
+
+## Publishing
+
+This repository includes a GitHub Actions workflow that publishes a new extension version when a tag like `v0.0.4` is pushed.
+
+Required repository secrets:
+
+- `VSCE_TOKEN` (Personal Access Token for VS Code Marketplace)
+- `OPEN_VSX_TOKEN` (Personal Access Token for Open VSX)
+
+Release steps:
+
+1. Bump `version` in `package.json`.
+2. Commit the change.
+3. Create and push a tag that matches the new version (for example `v0.0.4`).
+
+The workflow will package a `.vsix` and publish it to both registries.


### PR DESCRIPTION
## Summary
- replace the release workflow to package once and publish to both VS Code Marketplace and Open VSX
- switch release trigger to version tags (`v*`) plus manual dispatch so publishing is explicit and repeatable
- document Cursor availability details, required secrets, and release steps in the README

## Test plan
- [ ] Add repository secrets: `VSCE_TOKEN` and `OPEN_VSX_TOKEN`
- [ ] Bump `version` in `package.json`
- [ ] Push tag like `v0.0.4` and confirm workflow run succeeds
- [ ] Verify new version appears in VS Code Marketplace
- [ ] Verify new version appears in Open VSX and becomes discoverable in Cursor after sync

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the GitHub Actions release workflow and README documentation, with no runtime extension code changes. Main risk is misconfigured tokens or tag-triggering causing failed/incorrect releases.
> 
> **Overview**
> Switches the extension release workflow to run only on manual dispatch or `v*` tags, package the `.vsix` once, and publish to **both** the VS Code Marketplace and **Open VSX** (token-gated via `VSCE_TOKEN`/`OPEN_VSX_TOKEN`).
> 
> Updates the README to document Cursor availability, required secrets, and the tag-based release process.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34eb0e8f4c8133dd62239e8791c9c46b05a39f5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->